### PR TITLE
fix error on interpretation

### DIFF
--- a/subtitle/Chinese_English/Lecture 02  Bits, Bytes, and Integers.ass
+++ b/subtitle/Chinese_English/Lecture 02  Bits, Bytes, and Integers.ass
@@ -977,10 +977,10 @@ Dialogue: 0,0:50:48.26,0:50:51.70,English,,0,0,0,,And the point is that you had 
 Dialogue: 0,0:50:48.26,0:50:51.70,Chinese,,0,0,0,,关键是你必须使用这四个零中的一个
 Dialogue: 0,0:50:52.16,0:50:57.34,English,,0,0,0,,And so they're only there's one left one less value left over
 Dialogue: 0,0:50:52.16,0:50:57.34,Chinese,,0,0,0,,所以他们只剩下一个剩下的价值
-Dialogue: 0,0:50:57.72,0:51:01.82,English,,0,0,0,, And that's why you end up with this through a symmetry
-Dialogue: 0,0:50:57.72,0:51:01.82,Chinese,,0,0,0,,这就是为什么你通过对称结束这一点
-Dialogue: 0,0:51:02.50,0:51:06.92,English,,0,0,0,,And this a symmetry is the cause of no end of pain in various ways
-Dialogue: 0,0:51:02.50,0:51:06.92,Chinese,,0,0,0,,而这种对称性是以各种方式结束错误的原因
+Dialogue: 0,0:50:57.72,0:51:01.82,English,,0,0,0,, And that's why you end up with this through asymmetry
+Dialogue: 0,0:50:57.72,0:51:01.82,Chinese,,0,0,0,,这就是造成不对称性的原因
+Dialogue: 0,0:51:02.50,0:51:06.92,English,,0,0,0,,And this asymmetry is the cause of no end of pain in various ways
+Dialogue: 0,0:51:02.50,0:51:06.92,Chinese,,0,0,0,,而这种不对称性通过各种方式造成了无尽的困扰
 Dialogue: 0,0:51:07.72,0:51:15.62,English,,0,0,0,,That like a few the classic example is if you implement absolute value
 Dialogue: 0,0:51:07.72,0:51:15.62,Chinese,,0,0,0,,这就像一些经典的例子，如果你实现绝对值
 Dialogue: 0,0:51:33.40,0:51:39.96,English,,0,0,0,,Like so what do you what does this return for TMin


### PR DESCRIPTION
Line 980 - Line 983
 **a symmetry**应为**asymmetry**，原意应为"不对称性"。

补充了对应的中文翻译。